### PR TITLE
fix: disabled always override active

### DIFF
--- a/examples/demo.tsx
+++ b/examples/demo.tsx
@@ -39,21 +39,21 @@ const Test = React.createClass({
   render() {
     return (
       <div style={{margin: '20px'}}>
-        <div ref="log" style={{height:100,overflow:'auto',margin: 10}}/>
+        <div ref="log" style={{height: 100, overflow: 'auto', margin: 10}}/>
         <style dangerouslySetInnerHTML={{__html: style}}/>
         <Touchable
-          activeStyle={{border:'1px solid yellow', padding:5}}
+          activeStyle={{border: '1px solid yellow', padding: 5}}
           activeClassName="active"
           onPress={this.onPress}
           onLongPress={this.onLongPress}
         >
           <div
             style={{
-              width:100,
-              height:100,
-              border:'1px solid red',
-              boxSizing:'border-box',
-              WebkitUserSelect:'none',
+              width: 100,
+              height: 100,
+              border: '1px solid red',
+              boxSizing: 'border-box',
+              WebkitUserSelect: 'none',
             }}
           >click
           </div>

--- a/examples/disable.tsx
+++ b/examples/disable.tsx
@@ -1,0 +1,84 @@
+/* tslint:disable:no-console */
+
+import Touchable from 'rc-touchable';
+import React from 'react';
+import ReactDOM from 'react-dom';
+const style = `
+.foo-button {
+  display: inline-block;
+  width: 200px;
+  height: 100px;
+  border: 1px solid #ccc;
+  color: blue;
+}
+.foo-button.disabled {
+  background-color: black;
+}
+`;
+
+const Test = React.createClass({
+  getInitialState() {
+    return {
+      value: 1,
+      max: 3,
+      min: 1,
+    };
+  },
+  onPress(e) {
+    console.log('onPress', e);
+  },
+
+  onLongPress(e) {
+    console.log('onLongPress', e);
+  },
+  prev() {
+    this.setState({
+      value: this.state.value - 1,
+    });
+  },
+  next() {
+    this.setState({
+      value: this.state.value + 1,
+    });
+  },
+
+  render() {
+    const { value, min, max } = this.state;
+    return (
+      <div style={{margin: '20px'}}>
+        <style dangerouslySetInnerHTML={{__html: style}}/>
+        <Touchable
+          activeStyle={{border: '1px solid yellow', padding: 5}}
+          activeClassName="active"
+          onPress={this.onPress}
+          onLongPress={this.onLongPress}
+          disabled={value === min}
+        >
+          <a
+            className={`foo-button ${value === min ? 'disabled' : ''}`}
+            onClick={value === min ? undefined : this.prev}
+            role="button">
+              prev page
+          </a>
+        </Touchable>
+        <div>Now page: {value} </div>
+        <Touchable
+          activeStyle={{border: '1px solid yellow', padding: 5}}
+          activeClassName="active"
+          onPress={this.onPress}
+          onLongPress={this.onLongPress}
+          disabled={value === max}
+        >
+          <a
+            className={`foo-button ${value === max ? 'disabled' : ''}`}
+            onClick={value === max ? undefined : this.next}
+            role="button">
+              next page
+          </a>
+        </Touchable>
+      </div>
+    );
+  },
+});
+
+ReactDOM.render(<Test />, document.getElementById('__react-content'));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -482,7 +482,9 @@ const Touchable = React.createClass<ITouchable, any>({
   },
 
   touchableHandleActivePressIn(e) {
-    this.setActive(true);
+    if (!this.props.disabled) {
+      this.setActive(true);
+    }
     if (this.props.onPressIn) {
       this.props.onPressIn(e);
     }
@@ -655,7 +657,7 @@ const Touchable = React.createClass<ITouchable, any>({
         'onMouseDown',
       ]);
     const child = React.Children.only(children);
-    if (this.state.active) {
+    if (!disabled && this.state.active) {
       let { style, className } = child.props;
       if (activeStyle) {
         style = assign({}, style, activeStyle);


### PR DESCRIPTION
关联 https://github.com/react-component/touchable/pull/2 上次没有彻底修复

复现的场景可以看demo： https://mobile.ant.design/kitchen-sink/components/pagination?lang=en-US#pagination-demo-0 （chrome模拟器或真机）

即在 `onClick` 里面设置 `props.disabled = true`